### PR TITLE
Format top category insight dynamically

### DIFF
--- a/core/transformation_tracker.py
+++ b/core/transformation_tracker.py
@@ -345,9 +345,25 @@ class TransformationImpactTracker:
             # Category insights
             if analytics.top_transformation_categories:
                 top_cat = analytics.top_transformation_categories[0]
-                insights.append(f"Mental health shows highest transformation potential")
+                formatted_category = self._format_category_label(top_cat)
+                if formatted_category:
+                    insights.append(f"{formatted_category} shows highest transformation potential")
 
         return insights
+
+    @staticmethod
+    def _format_category_label(category_value: str) -> str:
+        """Format a category value into a human-friendly label."""
+        if not category_value:
+            return ""
+
+        try:
+            category_enum = TransformationCategory(category_value)
+            label_source = category_enum.value
+        except ValueError:
+            label_source = category_value
+
+        return label_source.replace('_', ' ').title()
 
     def _generate_recommendations(self) -> List[str]:
         """Generate recommendations based on data."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_transformation_tracker.py
+++ b/tests/test_transformation_tracker.py
@@ -1,0 +1,29 @@
+from core.transformation_tracker import (
+    TransformationCategory,
+    TransformationImpactTracker,
+    TransformationQuality,
+)
+
+
+def test_generate_insight_reflects_top_category(tmp_path):
+    data_dir = tmp_path / "transformations"
+    tracker = TransformationImpactTracker(str(data_dir))
+
+    tracker.submit_story(
+        {
+            "ai_system_name": "Career Coach AI",
+            "initial_state": "Uncertain about career path",
+            "final_state": "Found a fulfilling profession",
+            "transformation_category": TransformationCategory.CAREER_PURPOSE.value,
+            "transformation_quality": TransformationQuality.SIGNIFICANT.value,
+            "sustainability_score": 0.9,
+            "story_summary": "Career clarity achieved.",
+        }
+    )
+
+    report = tracker.generate_impact_report()
+
+    assert (
+        "Career Purpose shows highest transformation potential"
+        in report["insights"]
+    )


### PR DESCRIPTION
## Summary
- format the transformation insight message to display the highest-ranking category with a readable label
- add a pytest conftest to expose the project root on sys.path for imports
- cover the new behavior with a test that verifies non-mental-health categories appear in insights

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb1c8802ac832d92760bcfbb33d5ee