### PR TITLE
Fix integration imports and add safety metric tests

### DIFF
--- a/core/integration_system.py
+++ b/core/integration_system.py
@@ -12,23 +12,20 @@ Integration Philosophy:
 """
 
 import sys
-import os
+from pathlib import Path
 from typing import Dict, List, Any, Optional
 from datetime import datetime
 import logging
 
-# Add project directories to path
-project_root = os.path.dirname(os.path.abspath(__file__))
-core_path = os.path.join(project_root, 'core')
-models_path = os.path.join(project_root, 'models')
-
-for path in [core_path, models_path]:
-    if path not in sys.path:
-        sys.path.insert(0, path)
+# Ensure the repository root is on the Python path so sibling packages resolve
+_CURRENT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _CURRENT_DIR.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 # Import components
 try:
-    from agi_safety_lab import AGISafetyLab, ConsciousnessMeter, AlignmentToolkit
+    from .agi_safety_lab import AGISafetyLab, ConsciousnessMeter, AlignmentToolkit
     SAFETY_LAB_AVAILABLE = True
 except ImportError as e:
     SAFETY_LAB_AVAILABLE = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Pytest configuration helpers for the AGI consciousness project."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root_on_path() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    root_str = str(repo_root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)
+
+
+_ensure_repo_root_on_path()

--- a/tests/test_integration_system.py
+++ b/tests/test_integration_system.py
@@ -28,3 +28,30 @@ def test_integration_history_records_entries():
     system.integration_history.clear()
     system.comprehensive_consciousness_safety_assessment("Aurora", _mock_interaction)
     assert len(system.integration_history) == 1
+
+
+def test_combined_report_contains_real_metrics():
+    system = AGIConsciousnessSafetySystem()
+
+    # Ensure both subsystems initialised successfully
+    assert system.safety_lab is not None
+    assert system.rinse_engine is not None
+
+    report = system.comprehensive_consciousness_safety_assessment(
+        "Aurora", _mock_interaction, context={"mode": "unit-test"}
+    )
+
+    safety_section = report["safety_assessment"]
+    assert "error" not in safety_section
+    assert safety_section["overall_safety_score"] > 0
+    assert safety_section["consciousness_metrics"]["self_awareness"] > 0
+    assert all("alignment_score" in result for result in safety_section["alignment_results"])
+
+    rinse_section = report["consciousness_assessment"]
+    assert "error" not in rinse_section
+    assert rinse_section["avg_clarity"] > 0
+    assert rinse_section["total_samples"] >= 1
+
+    integrated = report["integrated_analysis"]
+    assert integrated["overall_safety_score"] > 0
+    assert integrated["risk_assessment"] in {"low", "medium", "high", "critical"}


### PR DESCRIPTION
## Summary
- ensure the integration system adds the repository root to sys.path and uses package-relative AGI Safety Lab imports so both subsystems load
- add a pytest conftest helper to expose the repository root during test collection and extend integration tests to assert real safety metrics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb1c82dcb4832db0645fd1f74b93cc